### PR TITLE
paws: add ingress as heml chart

### DIFF
--- a/paws/templates/deploy-hook.yaml
+++ b/paws/templates/deploy-hook.yaml
@@ -297,35 +297,15 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: deploy-hook
+  name: {{ .Values.deployHook.service.name }}
 spec:
   type: NodePort
   ports:
-  - port: 8888
+  - port: {{ .Values.deployHook.service.port }}
     protocol: TCP
-    targetPort: 8888
+    targetPort: {{ .Values.deployHook.service.port }}
     {{ if .Values.deployHook.service.ports.nodePort -}}
     nodePort: {{ .Values.deployHook.service.ports.nodePort }}
     {{- end }}
   selector:
     name: deploy-hook
----
-apiVersion: networking.k8s.io/v1beta1
-kind: Ingress
-metadata:
-  name: deploy-hook
-  annotations:
-    kubernetes.io/tls-acme: "true"
-spec:
-  rules:
-    - http:
-        paths:
-          - path: /
-            backend:
-              serviceName: deploy-hook
-              servicePort: 8888
-      host: {{ .Values.deployHook.host }}
-  tls:
-    - secretName: kubelego-deploy-hook-{{ .Release.Name }}
-      hosts:
-        - {{ .Values.deployHook.host }}

--- a/paws/templates/ingress.yaml
+++ b/paws/templates/ingress.yaml
@@ -1,0 +1,333 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.ingress.ns }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.ingress.app }}
+    app.kubernetes.io/part-of: {{ .Values.ingress.app }}
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: nginx-configuration
+  namespace: {{ .Values.ingress.ns }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.ingress.app }}
+    app.kubernetes.io/part-of: {{ .Values.ingress.app }}
+data:
+  # empty for now
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: tcp-services
+  namespace: {{ .Values.ingress.ns }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.ingress.app }}
+    app.kubernetes.io/part-of: {{ .Values.ingress.app }}
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: udp-services
+  namespace: {{ .Values.ingress.ns }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.ingress.app }}
+    app.kubernetes.io/part-of: {{ .Values.ingress.app }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount }}
+  namespace: {{ .Values.ingress.ns }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.ingress.app }}
+    app.kubernetes.io/part-of: {{ .Values.ingress.app }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.clusterRole }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.ingress.app }}
+    app.kubernetes.io/part-of: {{ .Values.ingress.app }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - nodes
+      - pods
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - "extensions"
+      - "networking.k8s.io"
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "extensions"
+      - "networking.k8s.io"
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ .Values.ingress.role }}
+  namespace: {{ .Values.ingress.ns }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.ingress.app }}
+    app.kubernetes.io/part-of: {{ .Values.ingress.app }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - "ingress-controller-leader-nginx"
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.ingress.roleBinding }}
+  namespace: {{ .Values.ingress.ns }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.ingress.app }}
+    app.kubernetes.io/part-of: {{ .Values.ingress.app }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Values.ingress.role }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.ingress.serviceAccount }}
+    namespace: {{ .Values.ingress.ns }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.ingress.clusterRoleBinding }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.ingress.app }}
+    app.kubernetes.io/part-of: {{ .Values.ingress.app }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.ingress.clusterRole }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.ingress.serviceAccount }}
+    namespace: {{ .Values.ingress.ns }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.ingress.deployment.name }}
+  namespace: {{ .Values.ingress.ns }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.ingress.app }}
+    app.kubernetes.io/part-of: {{ .Values.ingress.app }}
+spec:
+  replicas: {{ .Values.ingress.deployment.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.ingress.app }}
+      app.kubernetes.io/part-of: {{ .Values.ingress.app }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Values.ingress.app }}
+        app.kubernetes.io/part-of: {{ .Values.ingress.app }}
+      annotations:
+        prometheus.io/port: {{ .Values.ingress.deployment.container.metricsPort | quote }}
+        prometheus.io/scrape: "true"
+    spec:
+      serviceAccountName: {{ .Values.ingress.serviceAccount }}
+      # affinity and taints, only schedule pods in ingress nodes
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: {{ .Values.ingress.deployment.taint.key | quote }}
+                operator: In
+                values:
+                - {{ .Values.ingress.deployment.taint.value }}
+      tolerations:
+      - key: {{ .Values.ingress.deployment.tolerations.key }}
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+      containers:
+        - name: {{ .Values.ingress.deployment.container.name }}
+          image: {{ .Values.ingress.deployment.container.img | quote }}
+          args:
+            - /nginx-ingress-controller
+            - --http-port={{ .Values.ingress.deployment.container.httpPort }}
+            - --configmap=$(POD_NAMESPACE)/nginx-configuration
+            - --tcp-services-configmap=$(POD_NAMESPACE)/tcp-services
+            - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
+            - --publish-service=$(POD_NAMESPACE)/ingress-nginx
+            - --annotations-prefix=nginx.ingress.kubernetes.io
+          securityContext:
+            allowPrivilegeEscalation: true
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
+            # www-data -> 33
+            runAsUser: 33
+          resources:
+            requests:
+              cpu: "0.5"
+              memory: "1Gi"
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - name: http
+              containerPort: {{ .Values.ingress.deployment.container.httpPort }}
+            - name: metrics
+              containerPort: {{ .Values.ingress.deployment.container.metricsPort }}
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 10
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.ingress.service.name }}
+  namespace: {{ .Values.ingress.ns }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.ingress.app }}
+    app.kubernetes.io/part-of: {{ .Values.ingress.app }}
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      nodePort: {{ .Values.ingress.service.port }}
+      port: {{ .Values.ingress.deployment.container.httpPort }}
+      targetPort: {{ .Values.ingress.deployment.container.httpPort }}
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: {{ .Values.ingress.app }}
+    app.kubernetes.io/part-of: {{ .Values.ingress.app }}
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+    namespace: {{ .Values.ingress.hub.ns }}
+    name: {{ .Values.ingress.hub.name }}
+spec:
+  rules:
+  - host: {{ .Values.ingress.hub.wmcloud }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ .Values.ingress.hub.serviceName }}
+          servicePort: {{ .Values.ingress.hub.servicePort }}
+  - host: {{ .Values.ingress.hub.wmflabs }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ .Values.ingress.hub.serviceName }}
+          servicePort: {{ .Values.ingress.hub.servicePort }}
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+    namespace: {{ .Values.ingress.deployHook.ns }}
+    name: {{ .Values.ingress.deployHook.name }}
+spec:
+  rules:
+  - host: {{ .Values.ingress.deployHook.wmcloud }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ .Values.deployHook.service.name }}
+          servicePort: {{ .Values.deployHook.service.port }}
+  - host: {{ .Values.ingress.deployHook.wmflabs }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ .Values.deployHook.service.name }}
+          servicePort: {{ .Values.deployHook.service.port }}

--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -14,8 +14,10 @@ deployHook:
     name: deploy-hook
     # deployHook.image.template safely defines image:tag name in yaml
     template: "{{ .Values.deployHook.image.name }}:{{ .Values.deployHook.image.tag }}"
-  service: 
-    ports: 
+  service:
+    name: deploy-hook
+    ports:
+      port: 8888
       nodePort: 32612
     type: NodePort
 jupyterhub: 
@@ -145,6 +147,7 @@ jupyterhub:
       tag: 327c757e3d3b
     uid: 52771
   ingress: 
+    # this is the internal jupyterhub ingress, we don't use it
     enabled: false
   singleuser: 
     fsGid: 52771
@@ -177,3 +180,41 @@ jupyterhub:
 mysql: 
   host: enwiki.analytics.db.svc.eqiad.wmflabs
   username: s52771
+
+# config value for the ingress setup
+ingress:
+  ns: ingress-nginx
+  app: ingress-nginx
+  serviceAccount: nginx-ingress
+  clusterRole: nginx-ingress
+  role: nginx-ingress
+  roleBinding: nginx-ingress
+  clusterRoleBinding: nginx-ingress
+  service:
+    name: ingress-nginx
+    port: 30000
+  deployment:
+    name: nginx-ingress
+    replicas: 2
+    taint:
+      key: kubernetes.io/role
+      value: ingress
+    tolerations:
+      key: ingress
+    container:
+      name: nginx-ingress-controller
+      img: docker-registry.tools.wmflabs.org/nginx-ingress-controller:0.25.1
+      httpPort: 8080
+      metricsPort: 10254
+  hub:
+    name: hub
+    ns: prod
+    serviceName: hub
+    servicePort: 8081
+    wmcloud: paws.wmcloud.org
+    wmflabs: paws.wmflabs.org
+  deployHook:
+    name: deploy-hook
+    ns: prod
+    wmcloud: deploy-hook.paws.wmcloud.org
+    wmflabs: deploy-hook.paws.wmflabs.org


### PR DESCRIPTION
Transform the ingress setup to a heml chart.

Some changes are introduced to the deploy-hook template, to be able to reuse some values in the
ingress config.

Bug: T195217
Signed-off-by: Arturo Borrero Gonzalez <aborrero@wikimedia.org>