### PR TITLE
Proposed legacy URL ingress

### DIFF
--- a/paws/templates/legacy.yaml
+++ b/paws/templates/legacy.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   labels:
     name: paws-public-legacy
-    toolforge: tool
+    ingress.paws.wmcloud.org: legacy
   annotations:
     nginx.ingress.kubernetes.io/configuration-snippet: |
       rewrite /paws-public(/|$)*(.*) $scheme://public.paws.wmcloud.org/$2 redirect;
@@ -25,7 +25,7 @@ kind: Ingress
 metadata:
   labels:
     name: paws-legacy
-    toolforge: tool
+    ingress.paws.wmcloud.org: legacy
   annotations:
     nginx.ingress.kubernetes.io/configuration-snippet: |
       rewrite /paws(/|$)*(.*) $scheme://hub.paws.wmcloud.org/$2 redirect;

--- a/paws/templates/legacy.yaml
+++ b/paws/templates/legacy.yaml
@@ -1,0 +1,42 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  labels:
+    name: paws-public-legacy
+    toolforge: tool
+  annotations:
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      rewrite /paws-public(/|$)*(.*) $scheme://public.paws.wmcloud.org/$2 redirect;
+  name: paws-public-legacy
+spec:
+  rules:
+  - host: {{ .Values.pawspublic.ingress.legacyHost | quote }}
+    http:
+
+      paths:
+      # The backend portion is just there for the validator. It isn't used.
+      - backend:
+          serviceName: paws-public
+          servicePort: 8000
+        path: /paws-public(/|$)*(.*)
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  labels:
+    name: paws-legacy
+    toolforge: tool
+  annotations:
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      rewrite /paws(/|$)*(.*) $scheme://hub.paws.wmcloud.org/$2 redirect;
+  name: paws-legacy
+spec:
+  rules:
+  - host: {{ .Values.pawspublic.ingress.legacyHost | quote }}
+    http:
+      paths:
+      # The backend portion is just there for the validator. It isn't used.
+      - backend:
+          serviceName: paws-public
+          servicePort: 8000
+        path: /paws(/|$)*(.*)

--- a/paws/templates/legacy.yaml
+++ b/paws/templates/legacy.yaml
@@ -30,7 +30,7 @@ metadata:
   name: paws-legacy
 spec:
   rules:
-  - host: {{ .Values.pawspublic.ingress.legacyHost | quote }}
+  - host: {{ .Values.paws.ingress.legacyHost | quote }}
     http:
       paths:
       # The backend portion is just there for the validator. It isn't used.

--- a/paws/templates/legacy.yaml
+++ b/paws/templates/legacy.yaml
@@ -5,8 +5,7 @@ metadata:
     name: paws-public-legacy
     ingress.paws.wmcloud.org: legacy
   annotations:
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      rewrite /paws-public(/|$)*(.*) $scheme://public.paws.wmcloud.org/$2 redirect;
+    nginx.ingress.kubernetes.io/temporal-redirect: $scheme://{{ .Values.pawspublic.ingress.host }}/$2
   name: paws-public-legacy
 spec:
   rules:
@@ -27,8 +26,7 @@ metadata:
     name: paws-legacy
     ingress.paws.wmcloud.org: legacy
   annotations:
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      rewrite /paws(/|$)*(.*) $scheme://hub.paws.wmcloud.org/$2 redirect;
+    nginx.ingress.kubernetes.io/temporal-redirect: $scheme://{{ index .Values.jupyterhub.hub.ingress.hosts 0 }}/$2
   name: paws-legacy
 spec:
   rules:

--- a/paws/templates/legacy.yaml
+++ b/paws/templates/legacy.yaml
@@ -17,7 +17,7 @@ spec:
       - backend:
           serviceName: paws-public
           servicePort: 8000
-        path: /paws-public(/|$)*(.*)
+        path: /paws-public(/|$)(.*)
 ---
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
@@ -37,4 +37,4 @@ spec:
       - backend:
           serviceName: paws-public
           servicePort: 8000
-        path: /paws(/|$)*(.*)
+        path: /paws(/|$)(.*)

--- a/paws/templates/public.yaml
+++ b/paws/templates/public.yaml
@@ -105,7 +105,7 @@ kind: Ingress
 metadata:
   labels:
     name: paws-public-custom
-    toolforge: tool
+    ingress.paws.wmcloud.org: public
   name: paws-public-custom
 spec:
   rules:

--- a/paws/values.yaml
+++ b/paws/values.yaml
@@ -25,6 +25,10 @@ pawspublic:
     replicas: 1
   ingress:
     host: public.paws.wmcloud.org
+    legacyHost: paws-public.wmflabs.org
+paws:
+  ingress:
+    legacyHost: paws.wmflabs.org
 deployHook:
   # deployHook.enabled determines if we are running hte deployhook or not
   enabled: False


### PR DESCRIPTION
This feels a bit like a hack, but honestly, it seems to work when I test it locally.  We just need a couple lines in nginx. If this method is used, then we could set acme-chief to do TLS for paws and paws-public.wmflabs.org, then when we are ready to cut over, just switch the DNS directly. 

The system would then issue a 302 for the older URLs and correct the path. Then perhaps we'd switch to 301 or 308 after a little bit or perhaps after proving it works live?