### PR TITLE
URL encode path to file after replacing user name with user id

### DIFF
--- a/images/nbserve/nginx.py
+++ b/images/nbserve/nginx.py
@@ -139,7 +139,7 @@ http {
 
                         ngx.shared.usernamemapping:set(m[1], userid);
                     end
-                    ngx.req.set_uri("/" .. userid  .. m[2], true);
+                    ngx.req.set_uri("/" .. userid  .. ngx.escape_uri(m[2]), true);
                 end
             ';
 


### PR DESCRIPTION
Make URLs safe for processing by nginx before returning from LUA by reapplying URL encoding following replacement of the `User:<name>` path component with the associated Wikimedia SUL account's uid.

Bug: T258304