### PR TITLE
URL encode path to file after replacing user name with user id

### DIFF
--- a/images/nbserve/nginx.py
+++ b/images/nbserve/nginx.py
@@ -139,7 +139,7 @@ http {
 
                         ngx.shared.usernamemapping:set(m[1], userid);
                     end
-                    ngx.req.set_uri("/" .. userid  .. m[2], true);
+                    ngx.req.set_uri("/" .. userid  .. ngx.escape_uri(m[2], 0), true);
                 end
             ';
 


### PR DESCRIPTION
Make URLs safe for processing by nginx before returning from LUA by
reapplying URL encoding following replacement of the `User:<name>` path
component with the associated Wikimedia SUL account's uid. See
<https://github.com/openresty/lua-nginx-module#ngxescape_uri> for the
docs on using `ngx.escape_uri`. We need the escape to run as a full URI
escape in this case so that whitespace is encoded, but path separators
are not.

Bug: T258304