### PR TITLE
Revert "URL encode path to file after replacing user name with user id"

### DIFF
--- a/images/nbserve/nginx.py
+++ b/images/nbserve/nginx.py
@@ -139,7 +139,7 @@ http {
 
                         ngx.shared.usernamemapping:set(m[1], userid);
                     end
-                    ngx.req.set_uri("/" .. userid  .. ngx.escape_uri(m[2], 0), true);
+                    ngx.req.set_uri("/" .. userid  .. m[2], true);
                 end
             ';
 


### PR DESCRIPTION
Reverts crookedstorm/paws#6 It is misbehaving as well, unfortunately.